### PR TITLE
Fix the bug where validation returns "ok" when only a globalrule exists but fails

### DIFF
--- a/src/validator.php
+++ b/src/validator.php
@@ -200,6 +200,8 @@ class Validator
 	{
 		$this->_global_errors[]	=	$message;
 
+		$this->setHasError(true);
+		
 		return $this;
 	}
 


### PR DESCRIPTION
Repro before fix:

``` php
$data = [
  'firstname'   => '',
  'lastname'    => '',
];

$validator = new Validator;

$validator
      ->globalRule(new \Validation\NotEmpty(), Validator::OPERATOR_OR, 'Please indicate one of them')
        ->field('firstname')
        ->field('lastname')
  ->endGlobalRule();

$validator->run($data); //true (bug)
```
