### PR TITLE
Fix to not *independently re-run* rules associated to fields within OR rules.

### DIFF
--- a/src/field.php
+++ b/src/field.php
@@ -19,14 +19,16 @@ class Field
 	protected $_name;
 	protected $_rules	=	[ ];
 	protected $_validator;
+	protected $_operator;
 
 	protected $_error;
 	protected $_error_forced	=	false;
 
-	public function __construct($name, \Validator $validator)
+	public function __construct($name, \Validator $validator, $operator)
 	{
 		$this->_name		=	$name;
 		$this->_validator	=	$validator;
+		$this->_operator	=	$operator;
 	}
 
 	/**
@@ -165,6 +167,16 @@ class Field
 		$this->_error_forced	=	false;
 	}
 
+	/**
+	 * Returns the operator the field belongs to.
+	 * 
+	 * @return $operator
+	 */
+	public function getOperator()
+	{
+		return $this->_operator;
+	}
+	
 	/**
 	 * Check if a key exists in a form and returns it.
 	 *

--- a/src/validator.php
+++ b/src/validator.php
@@ -41,8 +41,15 @@ class Validator
 	{
 		$this->_current_field	=	$field;
 
-		if( ! isset($this->_fields[$field]))
-			$this->_fields[$field]	=	new \Validator\Field($field, $this);
+		//Mark he field as belonging to a AND rule.
+		if(empty($this->__and_or_stack) || current($this->__and_or_stack) === self::OPERATOR_AND)
+			$operator	=	self::OPERATOR_AND;
+		else
+			$operator	=	self::OPERATOR_OR;
+
+		$field_validator		=	new \Validator\Field($field, $this, $operator);
+
+		$this->_fields[$field]	=	$field_validator;
 
 		// Initializes it with global 'and' rules
 		if($this->_temp_and)
@@ -246,9 +253,12 @@ class Validator
 				$this->globalError($or['message']);
 		}
 
-		// Then, run the other rules for each field
+		// Then, run the other rules for each field, but only if this field is part of a AND rule.
 		foreach($this->_fields as $field)
-			$field->run($values);
+		{
+			if($field->getOperator() === self::OPERATOR_AND)
+				$field->run($values);
+		}
 
 		return ! $this->_has_error;
 	}


### PR DESCRIPTION
Repro before fix:

``` php
$data       =       [
  'email'   => 'toto@gmail.com',
  'zip'     =>      ''
];

$validator  =       new Validator;

$validator
    ->globalRule(new \Validation\NotEmpty(), Validator::OPERATOR_OR, 'Please indicate one of them')
      ->field('email')
        ->rule(new \Validation\Email())
      ->field('zip')
        ->rule(new \Validation\Digits())
    ->endGlobalRule();

$e  =       $validator->run($data);

//Unexpected Output:
//FALSE => Array ( [zip] => The input may contain digits only )
//=> Unexpected as "email" validates
```
